### PR TITLE
Improve CedarScript and code formatting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -41,19 +41,26 @@ optionalModules = ["cv2", "pytesseract", "numpy", "requests"]
 try:
     for module in optionalModules:
         import_module(module)
-    ocrAvailable = True;
-    #following line is redundant, but is provided to suppress errors from language helpers like Pylance
-    import cv2; import pytesseract ; import numpy; import requests
-    print("All optional modules loaded. OCR features are available (if enabled in config)")
+    ocrAvailable = True
+    # following line is redundant, but is provided to suppress errors from language helpers like Pylance
+    import cv2
+    import pytesseract
+    import numpy
+    import requests
+
+    print(
+        "All optional modules loaded. OCR features are available (if enabled in config)"
+    )
 except ImportError as error:
-    print("Unable to import " + module +". OCR features are unavailable.")
-    ocrAvailable = False;
+    print("Unable to import " + module + ". OCR features are unavailable.")
+    ocrAvailable = False
 
 
 version = "0.6.1"
 configFile = "config.yaml"
 
 knownUsers = {}
+
 
 def change_reputation(username, change):
     try:
@@ -65,6 +72,7 @@ def change_reputation(username, change):
         with open(config["persistFile"], "w") as f:
             json.dump(knownUsers, f)
 
+
 def get_reputation(username):
     try:
         return knownUsers[username]
@@ -75,6 +83,7 @@ def get_reputation(username):
                 json.dump(knownUsers, f)
         return 0
 
+
 # Extract username of message sender, and return status based on classification and/or known user bypass
 def handle_message(author, content, attachments=[]):
     if author == config["bridgeBot"]:
@@ -82,12 +91,11 @@ def handle_message(author, content, attachments=[]):
         author = author.split("<", 1)[1].replace("@", "").strip()
         content = content.split(">", 1)[1]
 
-
-    #TODO: OCR functionality for image links on IRC
+    # TODO: OCR functionality for image links on IRC
     if (config["ocrEnable"] == True) and (ocrAvailable == True):
         for item in attachments:
-            #very naive filetype checker
-            #TODO: find a better way to check image type and validity.
+            # very naive filetype checker
+            # TODO: find a better way to check image type and validity.
             filetypes = [".jpg", ".jpeg", ".png"]
             for ftype in filetypes:
                 if ftype in item.url:
@@ -96,7 +104,7 @@ def handle_message(author, content, attachments=[]):
                     targetImageCV = cv2.imdecode(targetArray, cv2.IMREAD_UNCHANGED)
                     targetText = pytesseract.image_to_string(targetImageCV)
                     if config["debugMode"]:
-                        print("OCR result: "+targetText.strip())
+                        print("OCR result: " + targetText.strip())
                     content = content + targetText
                     break
 
@@ -146,7 +154,7 @@ async def sendNotifMessage(message, confidence=0.0, customMessage=""):
         if role.name == config["spamNotifyPing"]:
             notifPing = role.mention
 
-    if customMessage=="":
+    if customMessage == "":
         await notifChannel.send(
             f'{notifPing} {"**"} {config["spamNotifyMessage"]} {"**"} {message.jump_url}'
         )
@@ -170,18 +178,34 @@ def logMessage(message, confidence):
 
 
 async def messageDeleter(message):
-    if (config["autoDeleteAPI"] == "customMB"):
+    if config["autoDeleteAPI"] == "customMB":
         bridge = http.client.HTTPConnection(config["bridgeURL"])
-        bridge.request("DELETE", "/api/message", headers={'Content-Type': 'application/json'}, \
-            body='{"id": "%s", "channel": "%s", "protocol": "discord", "account": "discord.mydiscord"}' % (message.id, message.channel.name))
+        bridge.request(
+            "DELETE",
+            "/api/message",
+            headers={"Content-Type": "application/json"},
+            body='{"id": "%s", "channel": "%s", "protocol": "discord", "account": "discord.mydiscord"}'
+            % (message.id, message.channel.name),
+        )
         response = bridge.getresponse()
         responseText = response.read()
-        await sendNotifMessage(message, customMessage="**Automatic Deletion Result:** %s"%(responseText.decode("utf-8").strip()))
-        await sendNotifMessage(message, customMessage="**Message was:** `%s`"%(message.content))
+        await sendNotifMessage(
+            message,
+            customMessage="**Automatic Deletion Result:** %s"
+            % (responseText.decode("utf-8").strip()),
+        )
+        await sendNotifMessage(
+            message, customMessage="**Message was:** `%s`" % (message.content)
+        )
         alertMsg = await message.channel.send(config["publicDeleteNotice"])
         sleep(10)
-        bridge.request("DELETE", "/api/message", headers={'Content-Type': 'application/json'}, \
-            body='{"id": "%s", "channel": "%s", "protocol": "discord", "account": "discord.mydiscord"}' % (alertMsg.id, alertMsg.channel.name))
+        bridge.request(
+            "DELETE",
+            "/api/message",
+            headers={"Content-Type": "application/json"},
+            body='{"id": "%s", "channel": "%s", "protocol": "discord", "account": "discord.mydiscord"}'
+            % (alertMsg.id, alertMsg.channel.name),
+        )
 
 
 class BotInstance(discord.Client):
@@ -193,14 +217,16 @@ class BotInstance(discord.Client):
             author = message.author.name + "#" + message.author.discriminator
             content = message.content
             attachments = message.attachments
-            is_spam, confidence, author, content = handle_message(author, content, attachments)
+            is_spam, confidence, author, content = handle_message(
+                author, content, attachments
+            )
             print(f"Message from {author}: {content}")
             if config["debugMode"]:
                 print(confidence)
-                print("Is Spam:" +str(is_spam))
+                print("Is Spam:" + str(is_spam))
             if is_spam:
                 await sendNotifMessage(message, confidence)
-                if not (config['autoDeleteAPI'] == "none"):
+                if not (config["autoDeleteAPI"] == "none"):
                     await messageDeleter(message)
 
 
@@ -256,7 +282,7 @@ print("Cedar Sentinel version " + version + " starting up.")
 classifier = gptc.Classifier(spamModel)
 print("Spam Model Loaded!")
 
-with open('script.txt') as f:
+with open("script.txt") as f:
     script = f.read()
 interpreter = cedarscript.Interpreter(script)
 print("CedarScript Interpreter Loaded!")

--- a/bot.py
+++ b/bot.py
@@ -41,26 +41,19 @@ optionalModules = ["cv2", "pytesseract", "numpy", "requests"]
 try:
     for module in optionalModules:
         import_module(module)
-    ocrAvailable = True
-    # following line is redundant, but is provided to suppress errors from language helpers like Pylance
-    import cv2
-    import pytesseract
-    import numpy
-    import requests
-
-    print(
-        "All optional modules loaded. OCR features are available (if enabled in config)"
-    )
+    ocrAvailable = True;
+    #following line is redundant, but is provided to suppress errors from language helpers like Pylance
+    import cv2; import pytesseract ; import numpy; import requests
+    print("All optional modules loaded. OCR features are available (if enabled in config)")
 except ImportError as error:
-    print("Unable to import " + module + ". OCR features are unavailable.")
-    ocrAvailable = False
+    print("Unable to import " + module +". OCR features are unavailable.")
+    ocrAvailable = False;
 
 
 version = "0.6.1"
 configFile = "config.yaml"
 
 knownUsers = {}
-
 
 def change_reputation(username, change):
     try:
@@ -72,7 +65,6 @@ def change_reputation(username, change):
         with open(config["persistFile"], "w") as f:
             json.dump(knownUsers, f)
 
-
 def get_reputation(username):
     try:
         return knownUsers[username]
@@ -83,7 +75,6 @@ def get_reputation(username):
                 json.dump(knownUsers, f)
         return 0
 
-
 # Extract username of message sender, and return status based on classification and/or known user bypass
 def handle_message(author, content, attachments=[]):
     if author == config["bridgeBot"]:
@@ -91,11 +82,12 @@ def handle_message(author, content, attachments=[]):
         author = author.split("<", 1)[1].replace("@", "").strip()
         content = content.split(">", 1)[1]
 
-    # TODO: OCR functionality for image links on IRC
+
+    #TODO: OCR functionality for image links on IRC
     if (config["ocrEnable"] == True) and (ocrAvailable == True):
         for item in attachments:
-            # very naive filetype checker
-            # TODO: find a better way to check image type and validity.
+            #very naive filetype checker
+            #TODO: find a better way to check image type and validity.
             filetypes = [".jpg", ".jpeg", ".png"]
             for ftype in filetypes:
                 if ftype in item.url:
@@ -104,7 +96,7 @@ def handle_message(author, content, attachments=[]):
                     targetImageCV = cv2.imdecode(targetArray, cv2.IMREAD_UNCHANGED)
                     targetText = pytesseract.image_to_string(targetImageCV)
                     if config["debugMode"]:
-                        print("OCR result: " + targetText.strip())
+                        print("OCR result: "+targetText.strip())
                     content = content + targetText
                     break
 
@@ -154,7 +146,7 @@ async def sendNotifMessage(message, confidence=0.0, customMessage=""):
         if role.name == config["spamNotifyPing"]:
             notifPing = role.mention
 
-    if customMessage == "":
+    if customMessage=="":
         await notifChannel.send(
             f'{notifPing} {"**"} {config["spamNotifyMessage"]} {"**"} {message.jump_url}'
         )
@@ -178,34 +170,18 @@ def logMessage(message, confidence):
 
 
 async def messageDeleter(message):
-    if config["autoDeleteAPI"] == "customMB":
+    if (config["autoDeleteAPI"] == "customMB"):
         bridge = http.client.HTTPConnection(config["bridgeURL"])
-        bridge.request(
-            "DELETE",
-            "/api/message",
-            headers={"Content-Type": "application/json"},
-            body='{"id": "%s", "channel": "%s", "protocol": "discord", "account": "discord.mydiscord"}'
-            % (message.id, message.channel.name),
-        )
+        bridge.request("DELETE", "/api/message", headers={'Content-Type': 'application/json'}, \
+            body='{"id": "%s", "channel": "%s", "protocol": "discord", "account": "discord.mydiscord"}' % (message.id, message.channel.name))
         response = bridge.getresponse()
         responseText = response.read()
-        await sendNotifMessage(
-            message,
-            customMessage="**Automatic Deletion Result:** %s"
-            % (responseText.decode("utf-8").strip()),
-        )
-        await sendNotifMessage(
-            message, customMessage="**Message was:** `%s`" % (message.content)
-        )
+        await sendNotifMessage(message, customMessage="**Automatic Deletion Result:** %s"%(responseText.decode("utf-8").strip()))
+        await sendNotifMessage(message, customMessage="**Message was:** `%s`"%(message.content))
         alertMsg = await message.channel.send(config["publicDeleteNotice"])
         sleep(10)
-        bridge.request(
-            "DELETE",
-            "/api/message",
-            headers={"Content-Type": "application/json"},
-            body='{"id": "%s", "channel": "%s", "protocol": "discord", "account": "discord.mydiscord"}'
-            % (alertMsg.id, alertMsg.channel.name),
-        )
+        bridge.request("DELETE", "/api/message", headers={'Content-Type': 'application/json'}, \
+            body='{"id": "%s", "channel": "%s", "protocol": "discord", "account": "discord.mydiscord"}' % (alertMsg.id, alertMsg.channel.name))
 
 
 class BotInstance(discord.Client):
@@ -217,16 +193,14 @@ class BotInstance(discord.Client):
             author = message.author.name + "#" + message.author.discriminator
             content = message.content
             attachments = message.attachments
-            is_spam, confidence, author, content = handle_message(
-                author, content, attachments
-            )
+            is_spam, confidence, author, content = handle_message(author, content, attachments)
             print(f"Message from {author}: {content}")
             if config["debugMode"]:
                 print(confidence)
-                print("Is Spam:" + str(is_spam))
+                print("Is Spam:" +str(is_spam))
             if is_spam:
                 await sendNotifMessage(message, confidence)
-                if not (config["autoDeleteAPI"] == "none"):
+                if not (config['autoDeleteAPI'] == "none"):
                     await messageDeleter(message)
 
 
@@ -282,7 +256,7 @@ print("Cedar Sentinel version " + version + " starting up.")
 classifier = gptc.Classifier(spamModel)
 print("Spam Model Loaded!")
 
-with open("script.txt") as f:
+with open('script.txt') as f:
     script = f.read()
 interpreter = cedarscript.Interpreter(script)
 print("CedarScript Interpreter Loaded!")

--- a/cedarscript/definitions.py
+++ b/cedarscript/definitions.py
@@ -1,6 +1,15 @@
 keywords = ["if", "else", "end", "and", "or"]
-inputs = ["confidence", "reputation", "length"]
-actions = ["flag", "log", "increasereputation", "decreasereputation"]
+input_list = ["confidence", "reputation", "length"]
+action_list = [
+    "flag",
+    "log",
+    "loggood",
+    "logspam",
+    "logprobablygood",
+    "logprobablyspam",
+    "increasereputation",
+    "decreasereputation",
+]
 
 
 class CodePiece:
@@ -31,23 +40,14 @@ class Input(Identifier):
     _type = "Input"
 
 
-inputs = {
-    "confidence": Input("confidence"),
-    "reputation": Input("reputation"),
-    "length": Input("length"),
-}
+inputs = {input_: Input(input_) for input_ in input_list}
 
 
 class Action(Identifier):
     _type = "Action"
 
 
-actions = {
-    "flag": Action("flag"),
-    "log": Action("log"),
-    "increasereputation": Action("increasereputation"),
-    "decreasereputation": Action("decreasereputation"),
-}
+actions = {action: Action(action) for action in action_list}
 
 
 class Conjunction(Identifier):

--- a/cedarscript/interpreter.py
+++ b/cedarscript/interpreter.py
@@ -57,13 +57,8 @@ class Interpreter:
 
             return all(tests)
         elif isinstance(expression, list):
-            expressions = [
-                self.interpret_expression(e, inputs) for e in expression[::2]
-            ]
-            conjunctions = [
-                {"and": (lambda x, y: x and y), "or": (lambda x, y: x or y)}[e.name]
-                for e in expression[1::2]
-            ]
+            expressions = [self.interpret_expression(e, inputs) for e in expression[::2]]
+            conjunctions = [{"and": (lambda x, y: x and y), "or": (lambda x, y: x or y)}[e.name] for e in expression[1::2]]
 
             state = expressions.pop(0)
 

--- a/cedarscript/lexer.py
+++ b/cedarscript/lexer.py
@@ -1,5 +1,6 @@
 import cedarscript.definitions as definitions
 
+
 def split(code):
     code = code.lower()
 
@@ -31,8 +32,8 @@ def split(code):
         elif char == " ":
             tokens.append("")
             indices.append([])
-        elif not (char == '_' and tokens[-1].isalpha()):
-            raise definitions.CedarScriptSyntaxError(f'invalid character: `{char}`')
+        elif not (char == "_" and tokens[-1].isalpha()):
+            raise definitions.CedarScriptSyntaxError(f"invalid character: `{char}`")
     return tokens, indices
 
 

--- a/cedarscript/lexer.py
+++ b/cedarscript/lexer.py
@@ -1,5 +1,6 @@
 import cedarscript.definitions as definitions
 
+
 def split(code):
     code = code.lower()
 
@@ -31,8 +32,8 @@ def split(code):
         elif char == " ":
             tokens.append("")
             indices.append([])
-        elif not (char == '_' and tokens[-1].isalpha()):
-            raise definitions.CedarScriptSyntaxError(f'invalid character: `{char}`')
+        elif not (char == "_" and tokens[-1].isalpha()):
+            raise definitions.CedarScriptSyntaxError(f"invalid character: `{char}`")
     return tokens, indices
 
 
@@ -43,10 +44,7 @@ def compress(tokens, indices):
 
 
 def combine(tokens, indices):
-    return [
-        {"token": token, "location": location}
-        for token, location in zip(tokens, indices)
-    ]
+    return [{"token": token, "location": location} for token, location in zip(tokens, indices)]
 
 
 def lineify(tokens):

--- a/cedarscript/lexer.py
+++ b/cedarscript/lexer.py
@@ -1,6 +1,5 @@
 import cedarscript.definitions as definitions
 
-
 def split(code):
     code = code.lower()
 
@@ -32,8 +31,8 @@ def split(code):
         elif char == " ":
             tokens.append("")
             indices.append([])
-        elif not (char == "_" and tokens[-1].isalpha()):
-            raise definitions.CedarScriptSyntaxError(f"invalid character: `{char}`")
+        elif not (char == '_' and tokens[-1].isalpha()):
+            raise definitions.CedarScriptSyntaxError(f'invalid character: `{char}`')
     return tokens, indices
 
 

--- a/cedarscript/parser.py
+++ b/cedarscript/parser.py
@@ -26,7 +26,9 @@ def tag(tokens):
                 token["token"] = len(token["token"]) // 4
                 token["tag"] = "indent"
             else:
-                raise definitions.CedarScriptSyntaxError(f'unrecognized token: {token["token"]}')
+                raise definitions.CedarScriptSyntaxError(
+                    f'unrecognized token: {token["token"]}'
+                )
 
     return tokens
 
@@ -60,11 +62,15 @@ def blocks(lines):
         elif line["tokens"][0]["token"] == "end":
             stack.pop()
             if len(stack) == 0:
-                raise definitions.CedarScriptSyntaxError(f'`end` outside an `if`/`else` statement')
+                raise definitions.CedarScriptSyntaxError(
+                    f"`end` outside an `if`/`else` statement"
+                )
         elif line["tokens"][0]["token"] == "else":
             stack.pop()
             if len(stack) == 0:
-                raise definitions.CedarScriptSyntaxError(f'`else` outside an `if` statement')
+                raise definitions.CedarScriptSyntaxError(
+                    f"`else` outside an `if` statement"
+                )
             stack.append(stack[-1][-1]["if_false"])
         else:
             stack[-1].append(line)
@@ -76,33 +82,37 @@ def convert_comparisons(tokens):
     combined = []
     for token in tokens:
         if token["tag"] == "open_compare":
-            if 'working' in locals():
-                raise definitions.CedarScriptSyntaxError('comparisons cannot be nested')
+            if "working" in locals():
+                raise definitions.CedarScriptSyntaxError("comparisons cannot be nested")
             working = {"type": "comparison", "comparator": token["token"], "values": []}
         elif token["tag"] == "number":
             try:
                 working["values"].append(token["token"])
             except (NameError, UnboundLocalError):
-                raise definitions.CedarScriptSyntaxError('number outside comparison')
+                raise definitions.CedarScriptSyntaxError("number outside comparison")
         elif token["tag"] == "input":
             try:
                 working["values"].append(definitions.inputs[token["token"]])
             except (NameError, UnboundLocalError):
-                raise definitions.CedarScriptSyntaxError('input outside comparison')
+                raise definitions.CedarScriptSyntaxError("input outside comparison")
         elif token["tag"] == "close_compare":
             try:
                 combined.append(
                     definitions.Comparison(working["comparator"], working["values"])
                 )
             except (NameError, UnboundLocalError):
-                raise definitions.CedarScriptSyntaxError(f'closing comparator `{token["token"]}` without matching opening comparator')
+                raise definitions.CedarScriptSyntaxError(
+                    f'closing comparator `{token["token"]}` without matching opening comparator'
+                )
             del working
         elif token["token"] in ["and", "or"]:
             combined.append(definitions.conjunctions[token["token"]])
         elif token["tag"] in ["open_paren", "close_paren"]:
             combined.append(token["tag"])
         else:
-            raise definitions.CedarScriptSyntaxError(f'invalid token in boolean expression: {token["token"]}')
+            raise definitions.CedarScriptSyntaxError(
+                f'invalid token in boolean expression: {token["token"]}'
+            )
 
     return combined
 
@@ -118,11 +128,13 @@ def assemble_expression(expression):
             elif token == "close_paren":
                 stack.pop()
                 if len(stack) == 0:
-                    raise definitions.CedarScriptSyntaxError(f'`)` without matching `(`')
+                    raise definitions.CedarScriptSyntaxError(
+                        f"`)` without matching `(`"
+                    )
         else:
             stack[-1].append(token)
     if len(stack) != 1:
-        raise definitions.CedarScriptSyntaxError(f'`(` without matching `)`')
+        raise definitions.CedarScriptSyntaxError(f"`(` without matching `)`")
     return out
 
 

--- a/cedarscript/parser.py
+++ b/cedarscript/parser.py
@@ -26,9 +26,7 @@ def tag(tokens):
                 token["token"] = len(token["token"]) // 4
                 token["tag"] = "indent"
             else:
-                raise definitions.CedarScriptSyntaxError(
-                    f'unrecognized token: {token["token"]}'
-                )
+                raise definitions.CedarScriptSyntaxError(f'unrecognized token: {token["token"]}')
 
     return tokens
 
@@ -62,15 +60,11 @@ def blocks(lines):
         elif line["tokens"][0]["token"] == "end":
             stack.pop()
             if len(stack) == 0:
-                raise definitions.CedarScriptSyntaxError(
-                    f"`end` outside an `if`/`else` statement"
-                )
+                raise definitions.CedarScriptSyntaxError(f'`end` outside an `if`/`else` statement')
         elif line["tokens"][0]["token"] == "else":
             stack.pop()
             if len(stack) == 0:
-                raise definitions.CedarScriptSyntaxError(
-                    f"`else` outside an `if` statement"
-                )
+                raise definitions.CedarScriptSyntaxError(f'`else` outside an `if` statement')
             stack.append(stack[-1][-1]["if_false"])
         else:
             stack[-1].append(line)
@@ -82,37 +76,33 @@ def convert_comparisons(tokens):
     combined = []
     for token in tokens:
         if token["tag"] == "open_compare":
-            if "working" in locals():
-                raise definitions.CedarScriptSyntaxError("comparisons cannot be nested")
+            if 'working' in locals():
+                raise definitions.CedarScriptSyntaxError('comparisons cannot be nested')
             working = {"type": "comparison", "comparator": token["token"], "values": []}
         elif token["tag"] == "number":
             try:
                 working["values"].append(token["token"])
             except (NameError, UnboundLocalError):
-                raise definitions.CedarScriptSyntaxError("number outside comparison")
+                raise definitions.CedarScriptSyntaxError('number outside comparison')
         elif token["tag"] == "input":
             try:
                 working["values"].append(definitions.inputs[token["token"]])
             except (NameError, UnboundLocalError):
-                raise definitions.CedarScriptSyntaxError("input outside comparison")
+                raise definitions.CedarScriptSyntaxError('input outside comparison')
         elif token["tag"] == "close_compare":
             try:
                 combined.append(
                     definitions.Comparison(working["comparator"], working["values"])
                 )
             except (NameError, UnboundLocalError):
-                raise definitions.CedarScriptSyntaxError(
-                    f'closing comparator `{token["token"]}` without matching opening comparator'
-                )
+                raise definitions.CedarScriptSyntaxError(f'closing comparator `{token["token"]}` without matching opening comparator')
             del working
         elif token["token"] in ["and", "or"]:
             combined.append(definitions.conjunctions[token["token"]])
         elif token["tag"] in ["open_paren", "close_paren"]:
             combined.append(token["tag"])
         else:
-            raise definitions.CedarScriptSyntaxError(
-                f'invalid token in boolean expression: {token["token"]}'
-            )
+            raise definitions.CedarScriptSyntaxError(f'invalid token in boolean expression: {token["token"]}')
 
     return combined
 
@@ -128,13 +118,11 @@ def assemble_expression(expression):
             elif token == "close_paren":
                 stack.pop()
                 if len(stack) == 0:
-                    raise definitions.CedarScriptSyntaxError(
-                        f"`)` without matching `(`"
-                    )
+                    raise definitions.CedarScriptSyntaxError(f'`)` without matching `(`')
         else:
             stack[-1].append(token)
     if len(stack) != 1:
-        raise definitions.CedarScriptSyntaxError(f"`(` without matching `)`")
+        raise definitions.CedarScriptSyntaxError(f'`(` without matching `)`')
     return out
 
 

--- a/cedarscript/parser.py
+++ b/cedarscript/parser.py
@@ -60,11 +60,11 @@ def blocks(lines):
         elif line["tokens"][0]["token"] == "end":
             stack.pop()
             if len(stack) == 0:
-                raise definitions.CedarScriptSyntaxError(f'`end` outside an `if`/`else` statement')
+                raise definitions.CedarScriptSyntaxError(f"`end` outside an `if`/`else` statement")
         elif line["tokens"][0]["token"] == "else":
             stack.pop()
             if len(stack) == 0:
-                raise definitions.CedarScriptSyntaxError(f'`else` outside an `if` statement')
+                raise definitions.CedarScriptSyntaxError(f"`else` outside an `if` statement")
             stack.append(stack[-1][-1]["if_false"])
         else:
             stack[-1].append(line)
@@ -76,24 +76,22 @@ def convert_comparisons(tokens):
     combined = []
     for token in tokens:
         if token["tag"] == "open_compare":
-            if 'working' in locals():
-                raise definitions.CedarScriptSyntaxError('comparisons cannot be nested')
+            if "working" in locals():
+                raise definitions.CedarScriptSyntaxError("comparisons cannot be nested")
             working = {"type": "comparison", "comparator": token["token"], "values": []}
         elif token["tag"] == "number":
             try:
                 working["values"].append(token["token"])
             except (NameError, UnboundLocalError):
-                raise definitions.CedarScriptSyntaxError('number outside comparison')
+                raise definitions.CedarScriptSyntaxError("number outside comparison")
         elif token["tag"] == "input":
             try:
                 working["values"].append(definitions.inputs[token["token"]])
             except (NameError, UnboundLocalError):
-                raise definitions.CedarScriptSyntaxError('input outside comparison')
+                raise definitions.CedarScriptSyntaxError("input outside comparison")
         elif token["tag"] == "close_compare":
             try:
-                combined.append(
-                    definitions.Comparison(working["comparator"], working["values"])
-                )
+                combined.append(definitions.Comparison(working["comparator"], working["values"]))
             except (NameError, UnboundLocalError):
                 raise definitions.CedarScriptSyntaxError(f'closing comparator `{token["token"]}` without matching opening comparator')
             del working
@@ -118,11 +116,11 @@ def assemble_expression(expression):
             elif token == "close_paren":
                 stack.pop()
                 if len(stack) == 0:
-                    raise definitions.CedarScriptSyntaxError(f'`)` without matching `(`')
+                    raise definitions.CedarScriptSyntaxError(f"`)` without matching `(`")
         else:
             stack[-1].append(token)
     if len(stack) != 1:
-        raise definitions.CedarScriptSyntaxError(f'`(` without matching `)`')
+        raise definitions.CedarScriptSyntaxError(f"`(` without matching `)`")
     return out
 
 

--- a/modelbuilder.py
+++ b/modelbuilder.py
@@ -46,11 +46,7 @@ try:
                 except:
                     pass
         workspace["messages"] += spam_log
-        response = (
-            input("imported. Would you like to clear the now-imported spam log? [Y/N]?")
-            .strip()
-            .lower()
-        )
+        response = input("imported. Would you like to clear the now-imported spam log? [Y/N]?").strip().lower()
         if "y" in response:
             with open("spamLog.json", "w", encoding="utf-8") as f:
                 print("spam log cleared.")

--- a/modelbuilder.py
+++ b/modelbuilder.py
@@ -63,9 +63,7 @@ try:
         print(message)
         response = "________"
         while not response in "sgu":
-            response = (
-                input("[S]pam/[G]ood/[U]nknown/[Ctrl-C] Exit: ").strip().lower() + " "
-            )[0]
+            response = (input("[S]pam/[G]ood/[U]nknown/[Ctrl-C] Exit: ").strip().lower() + " ")[0]
         if response == "s":
             workspace["model"].append({"category": "spam", "text": message})
         elif response == "g":

--- a/modelbuilder.py
+++ b/modelbuilder.py
@@ -46,7 +46,11 @@ try:
                 except:
                     pass
         workspace["messages"] += spam_log
-        response = input("imported. Would you like to clear the now-imported spam log? [Y/N]?").strip().lower()
+        response = (
+            input("imported. Would you like to clear the now-imported spam log? [Y/N]?")
+            .strip()
+            .lower()
+        )
         if "y" in response:
             with open("spamLog.json", "w", encoding="utf-8") as f:
                 print("spam log cleared.")


### PR DESCRIPTION
## Improve CedarScript definitions code

I made some changes to simplify maintenance, and added `log_good`, `log_spam`,
`log_probably_good`, and `log_probably_spam` as actions, for when we add
auto-classification. These are not supported by CedarSentinel yet, so they
don't do anything, but the CedarScript interpreter can handle them without
errors now.

## Reformat code

I just ran `black *.py cedarscript/*.py`.
